### PR TITLE
OZ-624: Bump `eip-client` to `v2.2.0-SNAPSHOT` + update configs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <lombok.version>1.18.30</lombok.version>
-    <eip.client.version>2.1.0</eip.client.version>
+    <eip.client.version>2.2.0-SNAPSHOT</eip.client.version>
     <openmrs.watcher.version>4.1.0-SNAPSHOT</openmrs.watcher.version>
     <camel.openmrs.fhir.version>4.1.0-SNAPSHOT</camel.openmrs.fhir.version>
     <fhir-r4.version>7.0.0</fhir-r4.version>

--- a/senaite-openmrs/src/main/java/com/ozonehis/eip/openmrs/senaite/config/EIPAppConfig.java
+++ b/senaite-openmrs/src/main/java/com/ozonehis/eip/openmrs/senaite/config/EIPAppConfig.java
@@ -8,6 +8,7 @@
 package com.ozonehis.eip.openmrs.senaite.config;
 
 import org.openmrs.eip.app.config.AppConfig;
+import org.openmrs.eip.fhir.spring.OpenmrsFhirAppConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -15,5 +16,5 @@ import org.springframework.context.annotation.Import;
  * Import the {@link AppConfig} class to ensure that the required beans are created.
  */
 @Configuration
-@Import(AppConfig.class)
-public class OpenmrsWatcherConfig {}
+@Import({AppConfig.class, OpenmrsFhirAppConfig.class})
+public class EIPAppConfig {}

--- a/senaite-openmrs/src/main/resources/config/application.properties
+++ b/senaite-openmrs/src/main/resources/config/application.properties
@@ -5,9 +5,6 @@ eip.application.name=${EIP_APPLICATION_NAME:eip-openmrs-senaite}
 
 eip.home=${user.home}${file.separator}.${eip.application.name}
 
-# A comma separated list of database tables names to watch for changes
-eip.watchedTables=${EIP_WATCHED_TABLES}
-
 # The interval in milliseconds between polls of the retry queue by the retry route
 db-event.retry.interval=${DB_EVENT_RETRY_INTERVAL:1800000}
 

--- a/senaite-openmrs/src/main/resources/eip-openmrs-senaite.properties
+++ b/senaite-openmrs/src/main/resources/eip-openmrs-senaite.properties
@@ -25,10 +25,6 @@ openmrs.baseUrl=${OPENMRS_SERVER_URL}
 
 # The results encounter type for all patient result observations.
 results.encounterType.uuid=${OPENMRS_RESULTS_ENCOUNTER_TYPE_UUID}
-
-openmrs.identifier.type.uuid=${OPENMRS_IDENTIFIER_TYPE_UUID}
-
-concept.complex.uuid=${OPENMRS_CONCEPT_COMPLEX_UUID}
 # ----------------------------------------------------------------------------------------------------------------------
 
 # *********************** Configuration of the Senaite Web App *********************************************************
@@ -43,7 +39,4 @@ senaite.username=${SENAITE_SERVER_USER}
 senaite.password=${SENAITE_SERVER_PASSWORD}
 
 fhirR4.baseUrl=${openmrs.baseUrl}/ws/fhir2/R4
-
-# Lab Order Type (Bahmni specific)
-bahmni.test.orderType.uuid=${BAHMNI_TEST_ORDER_TYPE_UUID}
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-624

This PR does the following:
- Bumps `eip-client` to version `2.2.0-SNAPSHOT`
- Imports `OpenmrsFhirAppConfig`
- Removes stale configurations