### PR TITLE
Fix: Parameter 0 of constructor in `EncounterHandler` required a bean of type 'java.lang.String' that could not be found

### DIFF
--- a/senaite-openmrs/src/main/java/com/ozonehis/eip/openmrs/senaite/handlers/openmrs/EncounterHandler.java
+++ b/senaite-openmrs/src/main/java/com/ozonehis/eip/openmrs/senaite/handlers/openmrs/EncounterHandler.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import java.util.Collections;
 import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Bundle;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
 @Component
 public class EncounterHandler {
 

--- a/senaite-openmrs/src/main/java/com/ozonehis/eip/openmrs/senaite/processors/TaskProcessor.java
+++ b/senaite-openmrs/src/main/java/com/ozonehis/eip/openmrs/senaite/processors/TaskProcessor.java
@@ -21,6 +21,7 @@ import com.ozonehis.eip.openmrs.senaite.model.analysisRequest.response.Analyses;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
@@ -40,6 +41,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Setter
 @Getter
+@NoArgsConstructor
 @Component
 public class TaskProcessor implements Processor {
 


### PR DESCRIPTION
Fixes the below error:
```
2024-11-12 14:38:36 ***************************
2024-11-12 14:38:36 APPLICATION FAILED TO START
2024-11-12 14:38:36 ***************************
2024-11-12 14:38:36 
2024-11-12 14:38:36 Description:
2024-11-12 14:38:36 
2024-11-12 14:38:36 Parameter 0 of constructor in com.ozonehis.eip.openmrs.senaite.handlers.openmrs.EncounterHandler required a bean of type 'java.lang.String' that could not be found.
2024-11-12 14:38:36 
2024-11-12 14:38:36 The injection point has the following annotations:
2024-11-12 14:38:36     - @org.springframework.beans.factory.annotation.Autowired(required=true)
```